### PR TITLE
Add an invisible HTML comment at the top of the PR template (#8)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+<!-- 
+IMPORTANT: Please update the PR title to be descriptive of your changes.
+Default title "Pull Request Template" is just a placeholder.
+Example: "[Feature] Add user login functionality"
+-->
+
 # Pull Request Template
 
 ## Description


### PR DESCRIPTION
# [Chore] Update PR template to remind contributors to update PR title

## Description

This PR updates the `.github/pull_request_template.md` to include an HTML comment at the top reminding contributors to update the PR title. Previously, new PRs would often keep the placeholder title "Pull Request Template," which can be confusing.
Fixes #8 

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Documentation update
-   [ ] Other (please describe):

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand
    areas
-   [ ] I have added tests that prove my fix is effective or my feature
    works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have updated the documentation where necessary
-   [x] Updated `.github/pull_request_template.md`
-   [ ] Verified template displays correctly in GitHub PR editor

## Files changed

`.github/pull_request_template.md` – updated with HTML comment at the top.